### PR TITLE
Use correct embedding dimension for AzureOpenAIEmbeddings

### DIFF
--- a/model/api/embedding_models.py
+++ b/model/api/embedding_models.py
@@ -15,6 +15,8 @@ def load_embedding_model(model_identifier: str):
     if model_identifier == "fake":
         return FakeEmbeddings(size=EMBEDDING_DIMENSION)
     if model_identifier == "text-embedding-3-large":
-        return AzureOpenAIEmbeddings(model=model_identifier, chunk_size=1000)
+        return AzureOpenAIEmbeddings(
+            model=model_identifier, chunk_size=1000, dimensions=EMBEDDING_DIMENSION
+        )
     msg = "model_name=%s not recognised"
     raise ValueError(msg, model_identifier)


### PR DESCRIPTION
We use Bedrock in prod, which is 1024; Azure is convenient locally but defaults to 3072 which is inconsistent with the rest of the app