### PR TITLE
Disable opensearch-anomaly-detection in Docker

### DIFF
--- a/docker-compose-config/opensearch.Dockerfile
+++ b/docker-compose-config/opensearch.Dockerfile
@@ -1,4 +1,5 @@
-FROM opensearchproject/opensearch:3
+FROM opensearchproject/opensearch:3.1.0
 
+RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer


### PR DESCRIPTION
This caused build failures in CI because the latest opensearch:3 container automatically enables this plugin.

Stick opensearch to a more specific version (this is the most specific available in dockerhub rn) in the hope we'll have fewer surprises like this in the future