### PR TITLE
Allow access to users with any role

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -15,9 +15,15 @@ export async function isAuthorisedUser(header: string): Promise<boolean> {
     return false;
   }
 
+  /*
+  Checks the user has the required role for this app
+  (bypassing for now, as any role is allowed for Caddy Admin)
   return parsedToken.roles.some((role: string) => 
     role === process.env.REPO || role === "local-testing"
   )
+  */
+  return parsedToken.roles;
+
 }
 
 async function parseAuthToken(header: string) {
@@ -46,7 +52,7 @@ async function parseAuthToken(header: string) {
   }
 
   let roles = tokenContent.realm_access.roles || [];
-  console.debug(`Roles found for user ${email}: ${roles}`);
+  // console.debug(`Roles found for user ${email}: ${roles}`);
   return {
     email,
     roles,

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -15,13 +15,8 @@ export async function isAuthorisedUser(header: string): Promise<boolean> {
     return false;
   }
 
-  /*
-  Checks the user has the required role for this app
-  (bypassing for now, as any role is allowed for Caddy Admin)
-  return parsedToken.roles.some((role: string) => 
-    role === process.env.REPO || role === "local-testing"
-  )
-  */
+  // We have decided not to check Keycloak roles (any role is allowed)
+  // Therefore return all roles without filtering
   return parsedToken.roles;
 
 }
@@ -52,7 +47,7 @@ async function parseAuthToken(header: string) {
   }
 
   let roles = tokenContent.realm_access.roles || [];
-  // console.debug(`Roles found for user ${email}: ${roles}`);
+  
   return {
     email,
     roles,

--- a/model/api/auth/__init__.py
+++ b/model/api/auth/__init__.py
@@ -1,4 +1,4 @@
 from .endpoint_auth import get_current_user
-from .token_auth import get_authorised_user, parse_auth_token
+from .token_auth import get_authorised_user
 
-__all__ = ["get_current_user", "parse_auth_token", "get_authorised_user"]
+__all__ = ["get_current_user", "get_authorised_user"]

--- a/model/api/auth/endpoint_auth.py
+++ b/model/api/auth/endpoint_auth.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import Depends, Header, HTTPException
 from sqlmodel import Session, select
 
-from api.auth.token_auth import parse_auth_token
+from api.auth.token_auth import get_authorised_user
 from api.environment import get_session
 from api.models import User
 
@@ -41,7 +41,7 @@ def get_current_user(
     logger.debug("Auth from token: %s", authorization)
 
     try:
-        email, role_names = parse_auth_token(authorization)
+        email = get_authorised_user(authorization)
 
         # We have decided not to check Keycloak roles (any role is allowed)
 

--- a/model/api/auth/endpoint_auth.py
+++ b/model/api/auth/endpoint_auth.py
@@ -43,17 +43,7 @@ def get_current_user(
     try:
         email, role_names = parse_auth_token(authorization)
 
-        # Checks the user has the required role for this app
-        # (bypassing for now, as any role is allowed for Caddy Admin)
-        """
-        if config.app_name not in role_names:
-            logger.info("User %s does not have the required role", email)
-            raise HTTPException(
-                status_code=401,
-                detail="Unauthorised",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-        """
+        # We have decided not to check Keycloak roles (any role is allowed)
 
         statement = select(User).where(User.email == email)
         if user := session.exec(statement).one_or_none():

--- a/model/api/auth/endpoint_auth.py
+++ b/model/api/auth/endpoint_auth.py
@@ -5,7 +5,7 @@ from fastapi import Depends, Header, HTTPException
 from sqlmodel import Session, select
 
 from api.auth.token_auth import parse_auth_token
-from api.environment import config, get_session
+from api.environment import get_session
 from api.models import User
 
 logging.basicConfig(level=logging.INFO)
@@ -43,6 +43,9 @@ def get_current_user(
     try:
         email, role_names = parse_auth_token(authorization)
 
+        # Checks the user has the required role for this app
+        # (bypassing for now, as any role is allowed for Caddy Admin)
+        """
         if config.app_name not in role_names:
             logger.info("User %s does not have the required role", email)
             raise HTTPException(
@@ -50,6 +53,7 @@ def get_current_user(
                 detail="Unauthorised",
                 headers={"WWW-Authenticate": "Bearer"},
             )
+        """
 
         statement = select(User).where(User.email == email)
         if user := session.exec(statement).one_or_none():

--- a/model/api/auth/token_auth.py
+++ b/model/api/auth/token_auth.py
@@ -56,7 +56,7 @@ def __get_decoded_jwt(jwt_token: str, verify_signature: bool) -> dict:
         raise Exception(f"Unhanded decoding error: {e}")
 
 
-def parse_auth_token(auth_header: str) -> tuple[str, list[str]]:
+def get_authorised_user(auth_header: str) -> EmailStr | None:
     """
     Takes a Keycloak JWT (auth token) as input and returns the user's email address and associated roles.
     Use this function to identify the logged-in user, and which roles they are assigned by Keycloak.
@@ -84,23 +84,6 @@ def parse_auth_token(auth_header: str) -> tuple[str, list[str]]:
         logger.error(error_msg)
         raise ValueError(error_msg)
 
-    role_names = realm_access.get("roles")
-    logger.debug(f"Roles for found in token for {email}: {role_names}")
-    return email, role_names
+    # We have decided not to check Keycloak roles (any Keycloak role is allowed)
 
-
-def get_authorised_user(
-    auth_header, desired_roles: list[str] | None = None
-) -> EmailStr | None:
-    """
-    A simple wrapper function to check if the user has the required role to access the resource.
-    """
-    if desired_roles is None:
-        desired_roles = []
-    email, roles = parse_auth_token(auth_header)
-    if (
-        config.app_name in roles
-        or len([role for role in desired_roles if role in roles]) > 0
-    ):
-        return email
-    return None
+    return email

--- a/model/api/mcp_app.py
+++ b/model/api/mcp_app.py
@@ -57,7 +57,7 @@ def __validate_user_access(request: Request) -> EmailStr | None:
         return None
 
     token = auth_header.removeprefix("Bearer ")
-    authorised_user = get_authorised_user(token, KEYCLOAK_ALLOWED_ROLES)
+    authorised_user = get_authorised_user(token)
     if not authorised_user:
         logger.info("user not authorised for roles: %s", KEYCLOAK_ALLOWED_ROLES)
         return None

--- a/model/api/models.py
+++ b/model/api/models.py
@@ -23,11 +23,7 @@ def user_token(user):
         "email": user.email,
         "aud": "account",
         "exp": 1727262399,
-        "realm_access": {
-            "roles": [
-                config.app_name,
-            ]
-        },
+        "realm_access": {"roles": []},
         "resource_access": {"account": {"roles": ["view-profile"]}},
     }
     jwt_headers = {


### PR DESCRIPTION
We currently check for the `caddy` role before giving users access. We now want to allow any authenticated user to have access, regardless of what roles they have.

The model test user has been updated to not contain any roles.
