### PR TITLE
Make deployed SHAs accessible to clients

### DIFF
--- a/docker-compose-config/.env.example
+++ b/docker-compose-config/.env.example
@@ -3,6 +3,7 @@
 
 # Cookiecutter settings
 ENVIRONMENT=local
+GIT_SHA=local
 REPO=caddy
 DISABLE_AUTH_SIGNATURE_VERIFICATION=true
 UVICORN_RELOAD=true

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import '../../node_modules/i.ai-design-system/dist/iai-design-system.css';
 import LitWrapper from '@components/lit-wrapper.astro';
 
 const { title, error } = Astro.props;
+const version = `caddy-${process.env.GIT_SHA}`;
 ---
 
 <!doctype html>
@@ -11,6 +12,7 @@ const { title, error } = Astro.props;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={ version } />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{ title } - Caddy Admin</title>
 	</head>

--- a/frontend/src/pages/api/health.ts
+++ b/frontend/src/pages/api/health.ts
@@ -2,6 +2,7 @@ export function GET() {
   return new Response(
     JSON.stringify({
       status: "ok",
+      sha: process.env.GIT_SHA || null,
     }),
   );
 }

--- a/model/api/app.py
+++ b/model/api/app.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import time
 from typing import Annotated, AsyncIterator, Callable
 
@@ -85,7 +86,7 @@ async def log_requests(request: Request, call_next: Callable):
 
 @app.get("/healthcheck")
 async def health_check():
-    return {"status": "caddy is healthy"}
+    return {"status": "caddy is healthy", "sha": os.getenv("GIT_SHA", None)}
 
 
 @app.post("/search")

--- a/model/api/app.py
+++ b/model/api/app.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import os
 import time
 from typing import Annotated, AsyncIterator, Callable
 
@@ -86,7 +85,7 @@ async def log_requests(request: Request, call_next: Callable):
 
 @app.get("/healthcheck")
 async def health_check():
-    return {"status": "caddy is healthy", "sha": os.getenv("GIT_SHA", None)}
+    return {"status": "ok", "sha": config.git_sha}
 
 
 @app.post("/search")

--- a/model/api/config.py
+++ b/model/api/config.py
@@ -22,6 +22,7 @@ class CaddyConfig:
         sentry_dsn=None,
         s3_prefix="app_data",
         keycloak_allowed_roles=None,
+        git_sha=None,
     ):
         self.opensearch_kwargs = opensearch_kwargs
         self.opensearch_url_pipeline = opensearch_url_pipeline
@@ -37,6 +38,7 @@ class CaddyConfig:
         self.data_s3_bucket = data_s3_bucket
         self.s3_prefix = s3_prefix
         self.resource_url_template = resource_url_template
+        self.git_sha = git_sha
 
         self.os_index_name = (
             "caddy_text_chunks_test" if self.env == "TEST" else "caddy_text_chunks"

--- a/model/api/environments/local.py
+++ b/model/api/environments/local.py
@@ -52,4 +52,5 @@ config = CaddyConfig(
     disable_auth_signature_verification=True,
     auth_provider_public_key="None",
     keycloak_allowed_roles=keycloak_allowed_roles,
+    git_sha="local",
 )

--- a/model/api/environments/production.py
+++ b/model/api/environments/production.py
@@ -62,4 +62,5 @@ config = CaddyConfig(
     auth_provider_public_key=auth_provider_public_key,
     sentry_dsn=sentry_dsn,
     keycloak_allowed_roles=keycloak_allowed_roles,
+    git_sha=os.getenv("GIT_SHA"),
 )

--- a/model/api/environments/test.py
+++ b/model/api/environments/test.py
@@ -57,4 +57,5 @@ config = CaddyConfig(
     disable_auth_signature_verification=disable_auth_signature_verification,
     auth_provider_public_key=auth_provider_public_key,
     keycloak_allowed_roles=keycloak_allowed_roles,
+    git_sha=os.getenv("GIT_SHA", "test"),  # tests can override if they want
 )

--- a/model/tests/test_api.py
+++ b/model/tests/test_api.py
@@ -590,3 +590,8 @@ def test_get_collection_non_admin_user_is_attached_to(
     )
     assert response.status_code == 200
     assert len(response.json()["collections"]) == 1
+
+
+def test_healthcheck(client):
+    response = client.get("/healthcheck")
+    assert response.json()["sha"] == "test"

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -52,7 +52,7 @@ module "model" {
     "PORT" : local.backend_port,
     "REPO" : "caddy",
     "AWS_ACCOUNT_ID": var.account_id,
- 
+    "GIT_SHA": var.image_tag
   }
 
   secrets = [
@@ -103,7 +103,8 @@ module "frontend" {
     "APP_NAME" : "caddy"
     "PORT" : local.frontend_port,
     "REPO" : "caddy",
-    "BACKEND_HOST" : "http://${aws_service_discovery_service.service_discovery_service.name}.${aws_service_discovery_private_dns_namespace.private_dns_namespace.name}:${local.backend_port}"
+    "BACKEND_HOST" : "http://${aws_service_discovery_service.service_discovery_service.name}.${aws_service_discovery_private_dns_namespace.private_dns_namespace.name}:${local.backend_port}",
+    "GIT_SHA": var.image_tag
   }
 
   secrets = [


### PR DESCRIPTION
It's useful to know which version is deployed at a given moment, so add a SHA to the healthchecks and the frontend.

1. `http://model/healthcheck`
2. `http://frontend/api/health`
3. `<meta name="generator" content="caddy-abc1234..." />` in the frontend.

Also update `docker-compose` `.env` so that `GIT_SHA` is set to `local` in local envs, where a) we are usually between SHAs and b) the SHA is only a `git status` away anyway.

Elsewhere report the SHA as `null` so it's clear that it's missing, if it is missing.

It would be good to add the SHA to the frontend somewhere more obvious — we can do that once we've got a footer.