### PR TITLE
Render the version in the footer, with a link

### DIFF
--- a/frontend/src/components/footer.astro
+++ b/frontend/src/components/footer.astro
@@ -1,5 +1,15 @@
 ---
-  const { version, links, feedback } = Astro.props;
+const { version, links, feedback } = Astro.props;
+let githubLink, shortVersion;
+
+if (version && version != "local") {
+  githubLink = `https://github.com/i-dot-ai/caddy/commit/${version}`;
+  shortVersion = version.substring(0,6);
+} else {
+  githubLink = "#";
+  shortVersion = "local";
+}
+
 ---
 
 <footer class="iai-footer">
@@ -21,7 +31,9 @@
               </ul>
             }
             { version &&
-              <span class="govuk-body-xs govuk-!-margin-0">Version: { version }</span>
+            <span class="govuk-body-xs govuk-!-margin-0">
+              Version: <a href={ githubLink }>{ shortVersion }</a>
+            </span>
             }
           </div>
         }

--- a/frontend/src/components/footer.astro
+++ b/frontend/src/components/footer.astro
@@ -32,7 +32,7 @@ if (version && version != "local") {
             }
             { version &&
             <span class="govuk-body-xs govuk-!-margin-0">
-              Version: <a href={ githubLink }>{ shortVersion }</a>
+              Version: <a href={ githubLink }>{ shortVersion }<span class="govuk-visually-hidden"> on github</span></a>
             </span>
             }
           </div>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,7 +4,8 @@ import '../../node_modules/i.ai-design-system/dist/iai-design-system.css';
 import LitWrapper from '@components/lit-wrapper.astro';
 
 const { title, error } = Astro.props;
-const version = `caddy-${process.env.GIT_SHA}`;
+const version = process.env.GIT_SHA;
+const generator = `caddy-${ version }`;
 ---
 
 <!doctype html>
@@ -12,7 +13,7 @@ const version = `caddy-${process.env.GIT_SHA}`;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={ version } />
+		<meta name="generator" content={ generator } />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{ title } - Caddy Admin</title>
 	</head>
@@ -42,7 +43,7 @@ const version = `caddy-${process.env.GIT_SHA}`;
 			</main>
 		</div>
 
-		<Footer />
+		<Footer version={ version } />
 
 		<script>
 			import '../../node_modules/i.ai-design-system/dist/iai-design-system.js';


### PR DESCRIPTION
**When `GIT_SHA` is set** (i.e. in deployed envs): link goes to commit on GitHub.
<img width="848" alt="Screenshot 2025-07-01 at 17 31 49" src="https://github.com/user-attachments/assets/f39c36e3-9390-49b3-9089-3544a68c2034" />
<br />

**When `GIT_SHA` is not set** 
<img width="851" alt="Screenshot 2025-07-01 at 17 37 43" src="https://github.com/user-attachments/assets/f0fd247c-f83e-4ea2-a10c-0743c6cc79d7" />
<br />

**When `GIT_SHA` is `local`** (which is default in `docker-compose-config/.env.example`): link goes to `#`
<img width="860" alt="Screenshot 2025-07-01 at 17 32 43" src="https://github.com/user-attachments/assets/fb3afb8e-24ac-432c-aaeb-6d91c7a1089b" />
