### PR TITLE
Ensure footer is at bottom of page/screen

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -48,5 +48,11 @@ const version = `caddy-${process.env.GIT_SHA}`;
 			import '../../node_modules/i.ai-design-system/dist/iai-design-system.js';
 		</script>
 
+		<style is:global>
+			body:has(.iai-footer) .govuk-main-wrapper {
+				min-height: calc(100vh - 235px);
+			}
+		</style>
+
 	</body>
 </html>


### PR DESCRIPTION
Ensures the footer "sticks" to the bottom of the screen for pages that are shorter than the screen-height. Otherwise it scrolls with the page rather than being fully sticky, to match the header behaviour.