### PR TITLE
Add "Search" prefix to tool names

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3725,9 +3725,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/model/api/mcp_app.py
+++ b/model/api/mcp_app.py
@@ -151,6 +151,7 @@ async def list_tools() -> list[types.Tool]:
                     },
                 },
             },
+            annotations={"title": f"Search {collection.name}"},
         )
         for collection in collections
     ]


### PR DESCRIPTION
Prefix "Search " to tool names. Using the annotations for this as the main tool name doesn't allow for spaces.

https://trello.com/c/GunRAkUw
