### PR TITLE
Enable RDS performance insights

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,22 +1,24 @@
 module "rds" {
   #   source = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/rds"  # For testing local changes
-  source                 = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/rds?ref=v4.0.4-rds"
-  db_name = replace(var.project_name, "-", "_")
+  source                 = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/rds?ref=v4.1.1-rds"
+  db_name                = replace(var.project_name, "-", "_")
   kms_secrets_arn        = data.terraform_remote_state.platform.outputs.kms_key_arn
   name                   = local.name
   public_subnet_ids_list = data.terraform_remote_state.vpc.outputs.public_subnets
   service_sg_ids = [
     module.model.ecs_sg_id,
   ]
-  vpc_id                = data.terraform_remote_state.vpc.outputs.vpc_id
-  engine                = "aurora-postgresql"
-  engine_version        = "16.6"
-  family                = null
-  engine_mode           = "provisioned"
-  aurora_min_scaling    = 0.5
-  aurora_max_scaling    = 1
-  aurora_instance_count = 1
-  deletion_protection   = var.env == "dev" ? false : true
-  env                   = var.env
-  rds_vpn_access_ips    = var.developer_ips
+  vpc_id                                = data.terraform_remote_state.vpc.outputs.vpc_id
+  engine                                = "aurora-postgresql"
+  engine_version                        = "16.6"
+  family                                = null
+  engine_mode                           = "provisioned"
+  aurora_min_scaling                    = 0.5
+  aurora_max_scaling                    = 1
+  aurora_instance_count                 = 1
+  deletion_protection                   = var.env == "dev" ? false : true
+  env                                   = var.env
+  rds_vpn_access_ips                    = var.developer_ips
+  enable_performance_insights           = var.env == "dev" ? false : true
+  performance_insights_retention_period = var.env == "dev" ? 1 : 7
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -20,5 +20,5 @@ module "rds" {
   env                                   = var.env
   rds_vpn_access_ips                    = var.developer_ips
   enable_performance_insights           = var.env == "dev" ? false : true
-  performance_insights_retention_period = var.env == "dev" ? 1 : 7
+  performance_insights_retention_period = var.env == "dev" ? null : 7
 }


### PR DESCRIPTION
Performance Insights give you table and query level observability in your RDS cluster. This is extremely useful when debugging issues on a database level without needing direct access. Insights are stored for 7 days.