### PR TITLE
Only add Plausible for non-admin users

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -2,28 +2,7 @@ import 'dotenv/config';
 import { jwtVerify, decodeJwt, errors, importSPKI } from 'jose';
 
 
-export async function isAuthorisedUser(header: string): Promise<boolean> {
-  if (!process.env.REPO) {
-    console.error('REPO environment variable not set');
-    return false;
-  }
-
-  const parsedToken = await parseAuthToken(header);
-
-  if (!parsedToken) {
-    console.error('No token found for user');
-    return false;
-  }
-
-  /*
-   * We have decided not to check Keycloak roles (any role is allowed)
-   * Therefore return all roles without filtering
-   */
-  return parsedToken.roles;
-
-}
-
-async function parseAuthToken(header: string) {
+export async function parseAuthToken(header: string) {
   if (!header) {
     console.error('No auth token provided to parse');
     return null;

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -8,6 +8,9 @@ const { title, error } = Astro.props;
 const version = process.env.GIT_SHA;
 const generator = `caddy-${ version }`;
 const notification = Astro.url.searchParams.get('notification');
+
+const isAdmin = await Astro.session?.get('isAdmin');
+
 ---
 
 <!doctype html>
@@ -18,8 +21,12 @@ const notification = Astro.url.searchParams.get('notification');
 		<meta name="generator" content={ generator } />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{ title } - Caddy Admin</title>
-		<script is:inline defer data-domain={ process.env['DOMAIN'] } src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.js"></script>
-		<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+
+		{!isAdmin &&
+			<script is:inline defer data-domain={ process.env['DOMAIN'] } src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.js"></script>
+			<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+		}
+
 	</head>
 	<body class="govuk-template__body govuk-frontend-supported">
 


### PR DESCRIPTION
We only want to get analytics data for non-admin users. This PR allows that by checking the `ADMIN_USERS` env var and only adding the Plausible scripts if the user email doesn't exist there.

