### PR TITLE
Show duplicate URLs on Add resource page

### DIFF
--- a/frontend/src/components/duplicate-urls.ts
+++ b/frontend/src/components/duplicate-urls.ts
@@ -1,0 +1,59 @@
+/**
+ * Flags any duplicate URLs about to be added (also matches with/without trailing slashes)
+ * Requires data-textarea attribute containing the ID of the textarea to check for new URLs
+ * Requires data-existing-urls attribute containing an array of existing URLs to check - string[]
+ * Optional: Add any non-js content inside <duplicate-urls> <duplicate-urls> - this will be removed once the javascript takes over
+ */
+
+
+const DuplicateUrls = class extends HTMLElement {
+
+  connectedCallback() {
+
+    // listen for textarea changes
+    if (!this.dataset.textarea) {
+      return;
+    }
+    const textarea = document.getElementById(this.dataset.textarea) as HTMLTextAreaElement;
+    textarea?.addEventListener('keyup', () => {
+      this.#showDuplicates(textarea.value);
+    });
+
+    // clear existing content
+    this.innerHTML = '';
+
+  }
+
+
+  #showDuplicates(newUrlContent: string) {
+
+    const newUrls = newUrlContent.split(/\r?\n/)
+      .map((line) => line.trim().replace(/\/$/g, ''));
+    const existingUrls: string[] = JSON.parse(this.dataset.existingUrls || '[]');
+    const duplicates = existingUrls.filter((existingUrl) => newUrls.includes(existingUrl.replace(/\/$/g, '')));
+
+    if (duplicates.length) {
+      this.innerHTML = `
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Important</span>
+            The following URLs already exist in the collection and will be overwritten:
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+              ${duplicates.map((duplicate) => `
+                <li>${duplicate}</li>
+              `).join('\n')}
+            </ul>
+          </strong>
+        </div>
+      `;
+    } else {
+      this.innerHTML = '';
+    }
+
+  }
+
+
+};
+
+customElements.define('duplicate-urls', DuplicateUrls);

--- a/frontend/src/components/sortable-table.ts
+++ b/frontend/src/components/sortable-table.ts
@@ -1,3 +1,12 @@
+/**
+ * Makes tables sortable
+ * Wrap the table inside <sortable-table> <sortable-table>
+ * Add the data-sortable attribute to any <th> elements that can allow sorting
+ * Optional: Add a default aria-sort="ascending" attribute to any column that is sorted by default on page load
+ * Optional: The default sorting runs on the visible text for that column. You can override this by providing a data-sort attribute on a <td>, e.g. useful for dates/times
+ */
+
+
 const SortableTable = class extends HTMLElement {
 
   connectedCallback() {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -97,6 +97,7 @@ const isAdmin = await Astro.session?.get('isAdmin');
 			}
 			th[aria-sort]::after {
 				bottom: 1px;
+				color: #505a5f;
 				font-size: 0.875rem;
 				margin-left: 0.5rem;
 				position: relative;

--- a/frontend/src/logic/data.ts
+++ b/frontend/src/logic/data.ts
@@ -123,6 +123,7 @@ export enum ResourcePermission {
 
 export interface ResourceDetail {
   id: string,
+  url?: string,
   filename?: string,
   content_type: string,
   created_at?: string,

--- a/frontend/src/pages/collections/[collection]/resources/add.astro
+++ b/frontend/src/pages/collections/[collection]/resources/add.astro
@@ -1,16 +1,20 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import { getCollections, getCollection } from '@logic/data.ts';
+import { getCollections, getCollection, getResources } from '@logic/data.ts';
 
-let { collectionsData } = await getCollections(Astro.request.headers.get('x-amzn-oidc-accesstoken'));
+const token = Astro.request.headers.get('x-amzn-oidc-accesstoken');
+
+let { collectionsData } = await getCollections(token);
 
 const { collection: collectionId } = Astro.params;
 
-const { collection, error } = await getCollection(collectionId || '', Astro.request.headers.get('x-amzn-oidc-accesstoken'));
+const { collection, error } = await getCollection(collectionId || '', token);
+
+const resourcesData = await getResources(collectionId || '', 1, 9999, token);
 
 ---
 
-<Layout title={'Upload to ' + collection.name } error={ error }>
+<Layout title={'Add resources to ' + collection.name } error={ error }>
 
   <nav class="govuk-breadcrumbs govuk-!-margin-bottom-6" aria-label="Breadcrumb">
     <ol class="govuk-breadcrumbs__list">
@@ -30,7 +34,7 @@ const { collection, error } = await getCollection(collectionId || '', Astro.requ
   <div class="govuk-grid-row upload-page">
     <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">Upload</h1>
+      <h1 class="govuk-heading-l">Add resource(s)</h1>
 
       <p><strong>Collection:</strong> { collection.name }</p>
 
@@ -56,15 +60,17 @@ const { collection, error } = await getCollection(collectionId || '', Astro.requ
             <label class="govuk-label govuk-label--m" for="add-urls">Add URL(s)</label>
           </h2>
           <div id="add-urls-hint" class="govuk-hint">Add one URL per line</div>
-          <textarea class="govuk-textarea" id="add-urls" name="addUrls" rows="5" aria-describedby="add-urls-hint"></textarea>
+          <textarea class="govuk-textarea" id="add-urls" name="addUrls" rows="5" aria-describedby="add-urls-hint duplicates-warning"></textarea>
         </div>
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Important</span>
-            Uploading a URL that already exists in this collection will result in it being overwritten.
-          </strong>
-        </div>
+        <duplicate-urls id="duplicates-warning" data-textarea="add-urls" data-existing-urls={ JSON.stringify(resourcesData.resources.filter(resource => resource.url).map(resource => resource.url) ) }>
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Important</span>
+              Uploading a URL that already exists in this collection will result in it being overwritten.
+            </strong>
+          </div>
+        </duplicate-urls>
         <button class="govuk-button">Add URL(s)</button>
       </form>
 
@@ -76,7 +82,8 @@ const { collection, error } = await getCollection(collectionId || '', Astro.requ
 </Layout>
 
 
-<script src="../../../../components/upload-info.ts"></script>
+<script src="@components/duplicate-urls.ts"></script>
+<script src="@components/upload-info.ts"></script>
 
 
 <style is:global>

--- a/frontend/src/pages/collections/[collection]/resources/index.astro
+++ b/frontend/src/pages/collections/[collection]/resources/index.astro
@@ -7,7 +7,7 @@ const PAGE_SIZE = 50;
 
 const token = Astro.request.headers.get('x-amzn-oidc-accesstoken');
 
-let { collectionsData } = await getCollections(Astro.request.headers.get('x-amzn-oidc-accesstoken'));
+let { collectionsData } = await getCollections(token);
 
 const { collection: collectionId } = Astro.params;
 const { collection, error } = await getCollection(collectionId || '', token);
@@ -40,7 +40,7 @@ const resourcesData = await getResources(collectionId || '', 1, PAGE_SIZE, token
           <p><strong>Collection:</strong> { collection.name }</p>
 
       { (collection.permissions.includes(CollectionPermission.MANAGE_RESOURCES) || collectionsData.is_admin) &&
-        <a class="govuk-button govuk-!-margin-top-2" href="resources/add">Upload file(s)</a>
+        <a class="govuk-button govuk-!-margin-top-2" href="resources/add">Add resource(s)</a>
       }
 
           <p class="govuk-body-l govuk-!-margin-top-5">Showing { resourcesData.total } resources</p>

--- a/frontend/tests/tests.spec.ts
+++ b/frontend/tests/tests.spec.ts
@@ -93,10 +93,10 @@ test('Manage resources', async({ page }) => {
   await expect(page.locator('h1')).toContainText('Resources');
   await expect(page.locator(`p:has-text("${collectionName}")`)).toBeVisible();
   const resourceCount = await page.locator('tbody tr').count();
-  await page.locator('a:has-text("Upload file")').click();
+  await page.locator('a:has-text("Add resource")').click();
 
   // Upload page
-  await expect(page.locator('h1')).toContainText('Upload');
+  await expect(page.locator('h1')).toContainText('Add resource(s)');
   await expect(page.getByText(collectionName)).toBeVisible();
   await testAccessibility(page);
   const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Show a warning when duplicate URLs will be overwritten, e.g.:

<img width="2314" height="902" alt="image" src="https://github.com/user-attachments/assets/85a2f019-a522-46eb-855d-9a2ad3129796" />

