### PR TITLE
fix: Remove volume mount of home directory .aws folder

### DIFF
--- a/docker-compose-config/.env.example
+++ b/docker-compose-config/.env.example
@@ -12,6 +12,12 @@ UVICORN_RELOAD=true
 AZURE_OPENAI_API_KEY=<azure_openai_api_key>
 AZURE_OPENAI_ENDPOINT=<azure_openai_endpoint>
 OPENAI_API_VERSION=<openai_api_version>
+
+# AWS credentials
+AWS_ACCESS_KEY_ID=<aws_access_key_id>
+AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
+AWS_DEFAULT_REGION=us-east-1
+
 EMBEDDING_MODEL=text-embedding-3-large
 
 # Opensearch

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
     volumes:
       - ./model:/app
       - /app/.venv # do not clobber installed venv
-      - ~/.aws/:/root/.aws:ro
     healthcheck:
       test: curl --fail 'http://localhost:8080/healthcheck' || exit 1
       start_period: 60s


### PR DESCRIPTION
This stops the containers from having access to the user's AWS credentials. Set credentials explicitly in the container environment.

Resolves i-dot-ai/caddy#74